### PR TITLE
feat : 패스워드 변경을 위한 이메일 인증 및 패스워드 변경 기능 추가

### DIFF
--- a/module-api/src/main/java/inspiration/auth/AuthService.java
+++ b/module-api/src/main/java/inspiration/auth/AuthService.java
@@ -105,6 +105,4 @@ public class AuthService {
             throw new PostNotFoundException(ExceptionType.PASSWORD_NOT_MATCHED.getMessage());
         }
     }
-
-
 }

--- a/module-api/src/main/java/inspiration/emailauth/EmailAuthService.java
+++ b/module-api/src/main/java/inspiration/emailauth/EmailAuthService.java
@@ -1,5 +1,6 @@
 package inspiration.emailauth;
 
+import inspiration.ResultResponse;
 import inspiration.enumeration.ExceptionType;
 import inspiration.enumeration.ExpireTimeConstants;
 import inspiration.enumeration.RedisKey;
@@ -51,6 +52,16 @@ public class EmailAuthService {
                         .build());
 
         return PolicyRedirectViewUtil.redirectView();
+    }
+
+    public ResultResponse validAuthenticateEmailStatus(String email) {
+
+        if (emailAuthRepository.existsByEmail(email)) {
+
+            return ResultResponse.of(ExceptionType.EMAIL_ALREADY_AUTHENTICATED.getMessage(), true);
+        }
+
+        return ResultResponse.of(ExceptionType.EMAIL_NOT_AUTHENTICATED.getMessage(), false);
     }
 
     private void verifyEmail(String email) {

--- a/module-api/src/main/java/inspiration/emailauth/EmailSendService.java
+++ b/module-api/src/main/java/inspiration/emailauth/EmailSendService.java
@@ -1,38 +1,5 @@
 package inspiration.emailauth;
 
-import inspiration.enumeration.ExceptionType;
-import inspiration.exception.PostNotFoundException;
-import inspiration.property.MailProperties;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.mail.SimpleMailMessage;
-import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.scheduling.annotation.Async;
-import org.springframework.scheduling.annotation.EnableAsync;
-import org.springframework.stereotype.Service;
-
-@Service
-@EnableAsync
-@RequiredArgsConstructor
-@Slf4j
-public class EmailSendService {
-
-    private final JavaMailSender mailSender;
-    private final MailProperties mailProperties;
-    private final static String SUBJECT = "회원가입 이메일 인증";
-
-    @Async
-    public void send(String email, String authToken) {
-        try {
-            SimpleMailMessage simpleMailMessage = new SimpleMailMessage();
-            simpleMailMessage.setTo(email);
-            simpleMailMessage.setSubject(SUBJECT);
-            simpleMailMessage.setText(mailProperties.getAuthMail() + email + mailProperties.getAuthToken() + authToken);
-
-            mailSender.send(simpleMailMessage);
-        } catch (Exception e) {
-            log.debug(ExceptionType.FAILED_TO_SEND_MAIL.getMessage(), e.getMessage());
-            throw new PostNotFoundException(ExceptionType.FAILED_TO_SEND_MAIL.getMessage());
-        }
-    }
+public interface EmailSendService {
+    void send(String email, String authToken);
 }

--- a/module-api/src/main/java/inspiration/emailauth/SignUpEmailSendService.java
+++ b/module-api/src/main/java/inspiration/emailauth/SignUpEmailSendService.java
@@ -1,0 +1,36 @@
+package inspiration.emailauth;
+
+import inspiration.enumeration.ExceptionType;
+import inspiration.exception.PostNotFoundException;
+import inspiration.property.MailProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SignUpEmailSendService implements EmailSendService {
+
+    private final JavaMailSender mailSender;
+    private final MailProperties mailProperties;
+    private final static String SUBJECT = "회원가입 이메일 인증";
+
+    @Override
+    public void send(String email, String authToken) {
+
+        try {
+            SimpleMailMessage simpleMailMessage = new SimpleMailMessage();
+            simpleMailMessage.setTo(email);
+            simpleMailMessage.setSubject(SUBJECT);
+            simpleMailMessage.setText(mailProperties.getSignUpEmailSendMail() + email + mailProperties.getAuthToken() + authToken);
+
+            mailSender.send(simpleMailMessage);
+        } catch (Exception e) {
+            log.debug(ExceptionType.FAILED_TO_SEND_MAIL.getMessage(), e.getMessage());
+            throw new PostNotFoundException(ExceptionType.FAILED_TO_SEND_MAIL.getMessage());
+        }
+    }
+}

--- a/module-api/src/main/java/inspiration/emailauth/UpdatePasswordEmailSendService.java
+++ b/module-api/src/main/java/inspiration/emailauth/UpdatePasswordEmailSendService.java
@@ -1,0 +1,36 @@
+package inspiration.emailauth;
+
+import inspiration.enumeration.ExceptionType;
+import inspiration.exception.PostNotFoundException;
+import inspiration.property.MailProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class UpdatePasswordEmailSendService implements EmailSendService {
+
+    private final JavaMailSender mailSender;
+    private final MailProperties mailProperties;
+    private final static String SUBJECT = "비빌번호 변경";
+
+    @Override
+    public void send(String email, String authToken) {
+
+        try {
+            SimpleMailMessage simpleMailMessage = new SimpleMailMessage();
+            simpleMailMessage.setTo(email);
+            simpleMailMessage.setSubject(SUBJECT);
+            simpleMailMessage.setText(mailProperties.getUpdatePasswordEmailSendMail() + email + mailProperties.getAuthToken() + authToken);
+
+            mailSender.send(simpleMailMessage);
+        } catch (Exception e) {
+            log.debug(ExceptionType.FAILED_TO_SEND_MAIL.getMessage(), e.getMessage());
+            throw new PostNotFoundException(ExceptionType.FAILED_TO_SEND_MAIL.getMessage());
+        }
+    }
+}

--- a/module-api/src/main/java/inspiration/member/request/SignUpRequest.java
+++ b/module-api/src/main/java/inspiration/member/request/SignUpRequest.java
@@ -4,6 +4,7 @@ import inspiration.member.Member;
 import lombok.*;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import javax.validation.constraints.*;
 import java.util.Collections;
 
 @Getter
@@ -11,12 +12,20 @@ import java.util.Collections;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class SignUpRequest {
 
+    @Email(message = "올바른 이메일 주소를 입력해주세요.")
+    @NotBlank(message = "이메일은 필수 입력 입니다.")
     private String email;
 
+    @NotBlank(message = "올바른 닉네임을 입력해주세요.")
+    @Size(min = 4, max = 20, message = "닉네임은 4자 이상 20자 이하로 입력해주세요.")
     private String nickName;
 
+    @NotBlank(message = "올바른 비밀번호를 입력해주세요.")
+    @Size(min = 6, max = 20, message = "비밀번호는 6자 이상 20자 이하로 입력해주세요.")
     private String password;
 
+    @NotBlank(message = "올바른 비밀번호를 입력해주세요.")
+    @Size(min = 6, max = 20, message = "비밀번호는 6자 이상 20자 이하로 입력해주세요.")
     private String confirmPassword;
 
     @Builder

--- a/module-api/src/main/java/inspiration/member/request/UpdatePasswordRequest.java
+++ b/module-api/src/main/java/inspiration/member/request/UpdatePasswordRequest.java
@@ -4,11 +4,18 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class UpdatePasswordRequest {
 
+    @NotBlank(message = "올바른 비밀번호를 입력해주세요.")
+    @Size(min = 6, max = 20, message = "비밀번호는 6자 이상 20자 이하로 입력해주세요.")
     private String password;
 
+    @NotBlank(message = "올바른 비밀번호를 입력해주세요.")
+    @Size(min = 6, max = 20, message = "비밀번호는 6자 이상 20자 이하로 입력해주세요.")
     private String confirmPassword;
 }

--- a/module-api/src/main/java/inspiration/member/request/UpdatePasswordRequest.java
+++ b/module-api/src/main/java/inspiration/member/request/UpdatePasswordRequest.java
@@ -1,0 +1,14 @@
+package inspiration.member.request;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class UpdatePasswordRequest {
+
+    private String password;
+
+    private String confirmPassword;
+}

--- a/module-api/src/main/java/inspiration/signup/SignupService.java
+++ b/module-api/src/main/java/inspiration/signup/SignupService.java
@@ -1,0 +1,80 @@
+package inspiration.signup;
+
+import inspiration.ResultResponse;
+import inspiration.emailauth.EmailAuthRepository;
+import inspiration.enumeration.ExceptionType;
+import inspiration.exception.ConflictRequestException;
+import inspiration.exception.PostNotFoundException;
+import inspiration.member.MemberRepository;
+import inspiration.member.request.SignUpRequest;
+import inspiration.redis.RedisService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SignupService {
+
+    private final MemberRepository memberRepository;
+    private final EmailAuthRepository emailAuthRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public Long signUp(SignUpRequest request) {
+
+        verifyEmail(request.getEmail());
+        isValidEmail(request.getEmail());
+        isValidNickName(request.getNickName());
+        confirmPasswordCheck(request.getConfirmPassword(), request.getPassword());
+
+        return memberRepository.save(request.toEntity(passwordEncoder)).getId();
+    }
+
+    @Transactional(readOnly = true)
+    public ResultResponse checkNickName(String nickname) {
+
+        isValidNickName(nickname);
+
+        return ResultResponse.from("사용할 수 있는 닉네임입니다.");
+    }
+
+    public ResultResponse validSignUpEmailStatus(String email) {
+
+        if (memberRepository.existsByEmail(email)) {
+
+            return ResultResponse.of(ExceptionType.EMAIL_ALREADY_AUTHENTICATED.getMessage(), true);
+        }
+
+        return ResultResponse.of(ExceptionType.EMAIL_NOT_AUTHENTICATED.getMessage(), false);
+    }
+
+    private void confirmPasswordCheck(String confirmPasswordCheck, String password) {
+
+        if (!confirmPasswordCheck.equals(password)) {
+            throw new PostNotFoundException(ExceptionType.PASSWORD_NOT_MATCHED.getMessage());
+        }
+    }
+
+    private void verifyEmail(String email) {
+
+        if (!emailAuthRepository.existsByEmail(email)) {
+            throw new PostNotFoundException(ExceptionType.EMAIL_NOT_AUTHENTICATED.getMessage());
+        }
+    }
+
+    private void isValidNickName(String nickName) {
+
+        if (memberRepository.existsByNickname(nickName)) {
+            throw new ConflictRequestException(ExceptionType.EXISTS_NICKNAME.getMessage());
+        }
+    }
+
+    private void isValidEmail(String email) {
+
+        if (memberRepository.existsByEmail(email)) {
+            throw new ConflictRequestException(ExceptionType.EXISTS_EMAIL.getMessage());
+        }
+    }
+}

--- a/module-common/src/main/java/inspiration/config/WebConfig.java
+++ b/module-common/src/main/java/inspiration/config/WebConfig.java
@@ -39,7 +39,7 @@ public class WebConfig extends WebMvcConfigurationSupport {
 
         return new Docket(DocumentationType.SWAGGER_2)
                 .apiInfo(this.apiInfo())
-                .host("13.125.36.7")
+//                .host("13.125.36.7")
                 .select()
                 .apis(RequestHandlerSelectors.basePackage("inspiration.v1"))
                 .paths(PathSelectors.any())

--- a/module-common/src/main/java/inspiration/config/security/SecurityConfiguration.java
+++ b/module-common/src/main/java/inspiration/config/security/SecurityConfiguration.java
@@ -21,7 +21,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
     private final JwtProvider jwtProvider;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
-    public static final String [] ALLOWED_URI_PATTERN = {"/api/v1/members"};
+    public static final String[] ALLOWED_URI_PATTERN = {"/api/v1/signup", "/api/v1/auth"};
 
     @Bean
     @Override
@@ -64,8 +64,9 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
         return (web) -> web.ignoring().antMatchers("/v2/api-docs", "/swagger-resources/**",
-                "/swagger-ui.html", "/webjars/**", "/swagger/**", "/api/v1/members/**");
+                "/swagger-ui.html", "/webjars/**", "/swagger/**", "/api/v1/signup/**", "/api/v1/auth/**");
     }
+
     private String[] addMatchers(String[] patterns) {
         return Arrays.stream(patterns).map(pattern -> pattern.concat("/**")).collect(Collectors.toList()).toArray(String[]::new);
     }

--- a/module-common/src/main/java/inspiration/enumeration/ExceptionType.java
+++ b/module-common/src/main/java/inspiration/enumeration/ExceptionType.java
@@ -26,7 +26,9 @@ public enum ExceptionType {
 
     FAILED_TO_SEND_MAIL("메일 전송에 실패하였습니다."),
 
-    USER_NOT_EXISTS("존재하지 않는 유저입니다."),
+    USER_NOT_EXISTS("존재하지 않는 사용자입니다."),
+
+    USER_EXISTS("존재하는 사용자 입니다."),
 
     EXPIRED_REFRESH_TOKEN("이미 만료된 리프레시 토큰 입니다."),
 

--- a/module-common/src/main/java/inspiration/enumeration/ExpireTimeConstants.java
+++ b/module-common/src/main/java/inspiration/enumeration/ExpireTimeConstants.java
@@ -5,7 +5,9 @@ import lombok.Getter;
 @Getter
 public final class ExpireTimeConstants {
 
-    public static final Long expireAccessTokenTime = 60 * 5L;
+    public static final Long expireSingUpAccessTokenTime = 60 * 5L;
+
+    public static final Long expireUpdatePasswordAccessTokenTime = 60 * 30L;
 
     public static final Long accessTokenValidMillisecond = 60 * 60 * 1000L;
 

--- a/module-common/src/main/java/inspiration/enumeration/RedisKey.java
+++ b/module-common/src/main/java/inspiration/enumeration/RedisKey.java
@@ -5,7 +5,8 @@ import lombok.Getter;
 @Getter
 public enum RedisKey {
     REFRESH("REFRESH_"),
-    EAUTH("EAUTH_");
+    EAUTH_SIGN_UP("EAUTH_SIGN_UP"),
+    EAUTH_UPDATE_PASSWORD("EAUTH_UPDATE_PASSWORD");
 
     private final String key;
 

--- a/module-common/src/main/java/inspiration/property/MailProperties.java
+++ b/module-common/src/main/java/inspiration/property/MailProperties.java
@@ -15,6 +15,7 @@ public class MailProperties {
     private final int port;
     private final String userName;
     private final String password;
-    private final String authMail;
+    private final String signUpEmailSendMail;
+    private final String updatePasswordEmailSendMail;
     private final String authToken;
 }

--- a/module-domain/src/main/java/inspiration/member/Member.java
+++ b/module-domain/src/main/java/inspiration/member/Member.java
@@ -40,6 +40,11 @@ public class Member extends BaseTimeEntity implements UserDetails {
     @Builder.Default
     private List<String> roles = new ArrayList<>();
 
+    public void updatePassword(String password) {
+
+        this.password = password;
+    }
+
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return this.roles

--- a/module-web/src/main/java/inspiration/Application.java
+++ b/module-web/src/main/java/inspiration/Application.java
@@ -2,10 +2,8 @@ package inspiration;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.data.web.SpringDataWebAutoConfiguration;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
-import org.springframework.context.annotation.ComponentScan;
-
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
 @ConfigurationPropertiesScan("inspiration.property")

--- a/module-web/src/main/java/inspiration/v1/auth/AuthController.java
+++ b/module-web/src/main/java/inspiration/v1/auth/AuthController.java
@@ -1,16 +1,71 @@
 package inspiration.v1.auth;
 
+import inspiration.ResultResponse;
 import inspiration.auth.AuthService;
+import inspiration.auth.request.LoginRequest;
+import inspiration.emailauth.EmailAuthService;
+import inspiration.emailauth.request.AuthenticateEmailRequest;
+import inspiration.emailauth.request.SendEmailRequest;
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.view.RedirectView;
+
+import javax.validation.Valid;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/auth")
 public class AuthController {
+
+    private final EmailAuthService emailAuthService;
     private final AuthService authService;
+
+    @PostMapping("/login")
+    @ResponseStatus(HttpStatus.CREATED)
+    @ApiOperation(value = "로그인", notes = "이메일로 로그인을 합니다.")
+    public ResultResponse login(@RequestBody LoginRequest request) {
+
+        return authService.login(request);
+    }
+
+    @PostMapping("/sends-email")
+    @ResponseStatus(HttpStatus.CREATED)
+    @ApiOperation(value = "회원가입을 위해 이메일 인증 링크 요청", notes = "회원가입을 위해 이메일에 인증 링크를 요청한다")
+    public void signUpEmailSend(@RequestBody @Valid SendEmailRequest request) {
+
+        emailAuthService.signUpEmailSend(request.getEmail());
+    }
+
+    @PostMapping("/password/sends-email/{email}")
+    @ResponseStatus(HttpStatus.CREATED)
+    @ApiOperation(value = "비빌번호 변경을 위해 이메일 인증 링크 요청", notes = "비밀번호 변경을 위해 이메일에 인증 링크를 요청한다")
+    public void updatePasswordEmailSend(@PathVariable String email) {
+
+        emailAuthService.updatePasswordEmailSend(email);
+    }
+
+    @GetMapping("/email")
+    @ApiOperation(value = "회원가입을 위한 이메일 인증.", notes = "링크를 클릭하면 회원가입을 위한 이메일 인증에 성공한다.")
+    public RedirectView authenticateEmailOfSingUp(@ModelAttribute AuthenticateEmailRequest request) {
+
+        return emailAuthService.authenticateEmailOfSingUp(request.getEmail());
+    }
+
+    @GetMapping("/password/reset")
+    @ApiOperation(value = "비밀번호 변경을 위한 이메일 인증.", notes = "링크를 클릭하면 비밀번호 변경을 위한 이메일 인증에 성공한다.")
+    public RedirectView authenticateEmailOfPassword(@ModelAttribute AuthenticateEmailRequest request) {
+
+        return emailAuthService.authenticateEmailOfUpdatePassword(request.getEmail());
+    }
+
+    @GetMapping("/email/{email}/status")
+    @ApiOperation(value = "해당 이메일의 인증 상태 여부 반환", notes = "해당 이메일의 인증 상태 여부를 반환한다.")
+    public ResultResponse validAuthenticateEmailStatus(@PathVariable String email) {
+
+        return emailAuthService.validAuthenticateEmailStatus(email);
+    }
 
     @GetMapping("/authorization")
     public String getMemberInfo() {

--- a/module-web/src/main/java/inspiration/v1/auth/AuthController.java
+++ b/module-web/src/main/java/inspiration/v1/auth/AuthController.java
@@ -66,9 +66,4 @@ public class AuthController {
 
         return emailAuthService.validAuthenticateEmailStatus(email);
     }
-
-    @GetMapping("/authorization")
-    public String getMemberInfo() {
-        return authService.getUserInfo();
-    }
 }

--- a/module-web/src/main/java/inspiration/v1/member/MemberController.java
+++ b/module-web/src/main/java/inspiration/v1/member/MemberController.java
@@ -1,10 +1,14 @@
 package inspiration.v1.member;
 
+import inspiration.config.AuthenticationPrincipal;
 import inspiration.member.MemberService;
 import inspiration.member.request.UpdatePasswordRequest;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import springfox.documentation.annotations.ApiIgnore;
+
+import javax.validation.Valid;
 
 @RestController
 @RequiredArgsConstructor
@@ -13,10 +17,10 @@ public class MemberController {
 
     private final MemberService memberService;
 
-    @PutMapping("/{id}/passwords")
+    @PutMapping("/passwords/reset")
     @ApiOperation(value = "패스워드를 변경.", notes = "패스워드를 변경한다.")
-    public void updatePassword(@PathVariable Long id, @RequestBody UpdatePasswordRequest request) {
+    public void updatePassword(@ApiIgnore @AuthenticationPrincipal Long memberId, @RequestBody @Valid UpdatePasswordRequest request) {
 
-        memberService.updatePassword(id, request.getConfirmPassword(), request.getPassword());
+        memberService.updatePassword(memberId, request.getConfirmPassword(), request.getPassword());
     }
 }

--- a/module-web/src/main/java/inspiration/v1/member/MemberController.java
+++ b/module-web/src/main/java/inspiration/v1/member/MemberController.java
@@ -1,72 +1,22 @@
 package inspiration.v1.member;
 
-import inspiration.ResultResponse;
-import inspiration.auth.AuthService;
-import inspiration.auth.request.LoginRequest;
-import inspiration.emailauth.request.SendEmailRequest;
-import inspiration.emailauth.request.AuthenticateEmailRequest;
-import inspiration.emailauth.EmailAuthService;
 import inspiration.member.MemberService;
-import inspiration.member.request.SignUpRequest;
+import inspiration.member.request.UpdatePasswordRequest;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.servlet.view.RedirectView;
-
-import javax.validation.Valid;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/members")
 public class MemberController {
 
-    private final EmailAuthService emailAuthService;
     private final MemberService memberService;
-    private final AuthService authService;
 
-    @PostMapping("/confirm-email")
-    @ResponseStatus(HttpStatus.CREATED)
-    @ApiOperation(value = "이메일 인증 링크 요청", notes = "이메일에 인증 링크를 요청한다")
-    public void sendEmail(@RequestBody @Valid SendEmailRequest request) {
+    @PutMapping("/{id}/passwords}")
+    @ApiOperation(value = "패스워드를 변경.", notes = "패스워드를 변경한다.")
+    public void updatePassword(@PathVariable Long id, @RequestBody UpdatePasswordRequest request) {
 
-        emailAuthService.sendEmail(request.getEmail());
-    }
-
-    @PostMapping("/signup")
-    @ResponseStatus(HttpStatus.CREATED)
-    @ApiOperation(value = "회원가입", notes = "회원가입을 합니다.")
-    public Long singUp(@RequestBody SignUpRequest request) {
-
-        return memberService.signUp(request);
-    }
-
-    @PostMapping("/login")
-    @ResponseStatus(HttpStatus.CREATED)
-    @ApiOperation(value = "로그인", notes = "이메일로 로그인을 합니다.")
-    public ResultResponse login(@RequestBody LoginRequest request) {
-
-        return authService.login(request);
-    }
-
-    @GetMapping("/nicknames/{nickname}/exists")
-    @ApiOperation(value = "닉네임 중복 확인", notes = "중복된 닉네임이 있는지 검사합니다.")
-    public ResultResponse checkNickname(@PathVariable String nickname) {
-
-        return memberService.checkNickName(nickname);
-    }
-
-    @GetMapping("/auth-email")
-    @ApiOperation(value = "이메일 인증.", notes = "링크를 클릭하면 이메일 인증에 성공한다.")
-    public RedirectView authenticateEmail(@ModelAttribute AuthenticateEmailRequest request) {
-
-        return emailAuthService.authenticateEmail(request.getEmail());
-    }
-
-    @GetMapping("/auth-email/{email}/status")
-    @ApiOperation(value = "해당 이메일의 인증 상태 여부 반환", notes = "해당 이메일의 인증 상태 여부를 반환한다.")
-    public ResultResponse validAuthenticateEmailStatus(@PathVariable String email) {
-
-        return emailAuthService.validAuthenticateEmailStatus(email);
+        memberService.updatePassword(id, request.getConfirmPassword(), request.getPassword());
     }
 }

--- a/module-web/src/main/java/inspiration/v1/member/MemberController.java
+++ b/module-web/src/main/java/inspiration/v1/member/MemberController.java
@@ -63,10 +63,10 @@ public class MemberController {
         return emailAuthService.authenticateEmail(request.getEmail());
     }
 
-    @GetMapping("/test")
-    @ApiOperation(value = "테스트", notes = "테스트 api 입니다.")
-    public String test() {
+    @GetMapping("/auth-email/{email}/status")
+    @ApiOperation(value = "해당 이메일의 인증 상태 여부 반환", notes = "해당 이메일의 인증 상태 여부를 반환한다.")
+    public ResultResponse validAuthenticateEmailStatus(@PathVariable String email) {
 
-        return "hello";
+        return emailAuthService.validAuthenticateEmailStatus(email);
     }
 }

--- a/module-web/src/main/java/inspiration/v1/member/MemberController.java
+++ b/module-web/src/main/java/inspiration/v1/member/MemberController.java
@@ -13,7 +13,7 @@ public class MemberController {
 
     private final MemberService memberService;
 
-    @PutMapping("/{id}/passwords}")
+    @PutMapping("/{id}/passwords")
     @ApiOperation(value = "패스워드를 변경.", notes = "패스워드를 변경한다.")
     public void updatePassword(@PathVariable Long id, @RequestBody UpdatePasswordRequest request) {
 

--- a/module-web/src/main/java/inspiration/v1/reissue/ReissueController.java
+++ b/module-web/src/main/java/inspiration/v1/reissue/ReissueController.java
@@ -2,10 +2,12 @@ package inspiration.v1.reissue;
 
 import inspiration.ResultResponse;
 import inspiration.auth.AuthService;
+import inspiration.config.AuthenticationPrincipal;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+import springfox.documentation.annotations.ApiIgnore;
 
 @RestController
 @RequiredArgsConstructor
@@ -17,11 +19,8 @@ public class ReissueController {
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     @ApiOperation(value = "리프레쉬 토큰 재발급", notes = "리프레쉬 토큰을 재발급합니다.")
-    public ResultResponse reissue(
-            @RequestHeader(value = "X-AUTH-TOKEN") String accessToken,
-            @RequestHeader(value = "REFRESH-TOKEN") String refreshToken
-    ) {
+    public ResultResponse reissue(@RequestHeader(value = "REFRESH-TOKEN") String refreshToken, @ApiIgnore @AuthenticationPrincipal Long memberId) {
 
-        return authService.reissue(accessToken, refreshToken);
+        return authService.reissue(refreshToken, memberId);
     }
 }

--- a/module-web/src/main/java/inspiration/v1/signup/SignUpController.java
+++ b/module-web/src/main/java/inspiration/v1/signup/SignUpController.java
@@ -8,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/signup")
@@ -17,7 +19,7 @@ public class SignUpController {
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     @ApiOperation(value = "회원가입", notes = "회원가입을 합니다.")
-    public Long singUp(@RequestBody SignUpRequest request) {
+    public Long singUp(@RequestBody @Valid SignUpRequest request) {
 
         return signupService.signUp(request);
     }

--- a/module-web/src/main/java/inspiration/v1/signup/SignUpController.java
+++ b/module-web/src/main/java/inspiration/v1/signup/SignUpController.java
@@ -1,0 +1,38 @@
+package inspiration.v1.signup;
+
+import inspiration.ResultResponse;
+import inspiration.member.request.SignUpRequest;
+import inspiration.signup.SignupService;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/signup")
+public class SignUpController {
+    private final SignupService signupService;
+
+    @PostMapping("/signup")
+    @ResponseStatus(HttpStatus.CREATED)
+    @ApiOperation(value = "회원가입", notes = "회원가입을 합니다.")
+    public Long singUp(@RequestBody SignUpRequest request) {
+
+        return signupService.signUp(request);
+    }
+
+    @GetMapping("/nicknames/{nickname}/exists")
+    @ApiOperation(value = "닉네임 중복 확인", notes = "중복된 닉네임이 있는지 검사합니다.")
+    public ResultResponse checkNickname(@PathVariable String nickname) {
+
+        return signupService.checkNickName(nickname);
+    }
+
+    @GetMapping("/{email}/status")
+    @ApiOperation(value = "해당 유저가 가입되어 있는 유저인지 상태 여부 반환", notes = "해당 유저가 가입되어 있는 유저인지 상태 여부를 반환한다.")
+    public ResultResponse validSignUpEmailStatus(@PathVariable String email) {
+
+        return signupService.validSignUpEmailStatus(email);
+    }
+}

--- a/module-web/src/main/java/inspiration/v1/signup/SignUpController.java
+++ b/module-web/src/main/java/inspiration/v1/signup/SignUpController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 public class SignUpController {
     private final SignupService signupService;
 
-    @PostMapping("/signup")
+    @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     @ApiOperation(value = "회원가입", notes = "회원가입을 합니다.")
     public Long singUp(@RequestBody SignUpRequest request) {

--- a/module-web/src/main/resources/application-dev.yml
+++ b/module-web/src/main/resources/application-dev.yml
@@ -29,7 +29,8 @@ spring:
     port: ${MAIL_PORT}
     username: ${MAIL_USERNAME}
     password: ${MAIL_PASSWORD}
-    auth-mail: ${AUTH_MAIL}
+    sign-up-email-send-mail: ${SIGN_UP_EMAIL_SEND_MAIL}
+    update-password-email-send-mail: ${UPDATE_PASSWORD_EMAIL_SEND_MAIL}
     auth-token: ${AUTH_TOKEN}
 
   jwt:

--- a/module-web/src/main/resources/application-local.yml
+++ b/module-web/src/main/resources/application-local.yml
@@ -31,7 +31,8 @@ spring:
     port: ${MAIL_PORT}
     username: ${MAIL_USERNAME}
     password: ${MAIL_PASSWORD}
-    auth-mail: ${AUTH_MAIL}
+    sign-up-email-send-mail: ${SIGN_UP_EMAIL_SEND_MAIL}
+    update-password-email-send-mail: ${UPDATE_PASSWORD_EMAIL_SEND_MAIL}
     auth-token: ${AUTH_TOKEN}
 
   jwt:
@@ -63,6 +64,11 @@ logging:
         type:
           descriptor:
             sql: trace
-  pattern:
-    console: "[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c{1} - %msg%n"
+    com:
+      amazonaws:
+        util:
+          EC2MetadataUtils: error
+
+#  pattern:
+#    console: "[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c{1} - %msg%n"
 

--- a/module-web/src/main/resources/application.yml
+++ b/module-web/src/main/resources/application.yml
@@ -1,3 +1,3 @@
 spring:
   profiles:
-    active: local
+    active: dev


### PR DESCRIPTION
<!--
✅ Resolve: #이슈번호 형태로 입력해 주세요.
ex) Resolve: #123
-->
## 📌Linked Issues
- #32

<!--
✅ 변경 사항을 자세히 알려주세요. (why -> what -> how)
-->
## ✏Change Details
- 패스워드 변경을 위한 이메일 인증 기능 추가 -> 패스워드 인증 링크 유효기간 30분
- 패스워드 변경 기능 추가

<!--
✅ 추가로 전달할 내용이 있다면 적어주세요.
-->
## 💬Comment
- 기존 memberController가 너무 많은 책임을 지고 있는 것 같아서, `signUpController`, `authController`, `memberController`로 관심사 분리 하였습니다. Service Class도 마찬가지로 관심사 분리 적용하였습니다.
- 인증, 인가시에도 윗 처럼 분리했을때가 유지보수성 면에서 훨씬 효율적이였습니다.
- 회원 쪽 엔드포인트를 이 전보다는 더 restFul하게 설계해보았습니다.
- 리뷰 쥬세요~

<!--
✅ 참고한 사이트가 있다면 공유해주세요.
-->
## 📑References
- 

## ✅Check List
- [ ] 추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [ ] 코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?
