### PR TITLE
refactor: OpenGraph 데이터 조회 로직 개선

### DIFF
--- a/module-api/src/main/java/inspiration/inspiration/opengraph/OpenGraphService.java
+++ b/module-api/src/main/java/inspiration/inspiration/opengraph/OpenGraphService.java
@@ -1,0 +1,7 @@
+package inspiration.inspiration.opengraph;
+
+import java.util.Optional;
+
+public interface OpenGraphService {
+    Optional<OpenGraphVo> getMetadata(String url);
+}

--- a/module-api/src/main/java/inspiration/inspiration/opengraph/OpenGraphServiceImpl.java
+++ b/module-api/src/main/java/inspiration/inspiration/opengraph/OpenGraphServiceImpl.java
@@ -16,12 +16,12 @@ public class OpenGraphServiceImpl implements OpenGraphService {
         }
         return Optional.of(
                 OpenGraphVo.builder()
-                        .image(getValueSafely(openGraph, "image"))
-                        .siteName(getValueSafely(openGraph, "content"))
-                        .title(getValueSafely(openGraph, "title"))
-                        .url(getValueSafely(openGraph, "url"))
-                        .description(getValueSafely(openGraph, "description"))
-                        .build()
+                           .image(getValueSafely(openGraph, "image"))
+                           .siteName(getValueSafely(openGraph, "content"))
+                           .title(getValueSafely(openGraph, "title"))
+                           .url(getValueSafely(openGraph, "url"))
+                           .description(getValueSafely(openGraph, "description"))
+                           .build()
         );
     }
 

--- a/module-api/src/main/java/inspiration/inspiration/opengraph/OpenGraphServiceImpl.java
+++ b/module-api/src/main/java/inspiration/inspiration/opengraph/OpenGraphServiceImpl.java
@@ -1,0 +1,37 @@
+package inspiration.inspiration.opengraph;
+
+import com.github.siyoon210.ogparser4j.OgParser;
+import com.github.siyoon210.ogparser4j.OpenGraph;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class OpenGraphServiceImpl implements OpenGraphService {
+    public Optional<OpenGraphVo> getMetadata(String url) {
+        OgParser ogParser = new OgParser(new YgtangOgMetaElementHtmlParser());
+        OpenGraph openGraph = ogParser.getOpenGraphOf(url);
+        if (openGraph.getAllProperties().isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(
+                OpenGraphVo.builder()
+                        .image(getValueSafely(openGraph, "image"))
+                        .siteName(getValueSafely(openGraph, "content"))
+                        .title(getValueSafely(openGraph, "title"))
+                        .url(getValueSafely(openGraph, "url"))
+                        .description(getValueSafely(openGraph, "description"))
+                        .build()
+        );
+    }
+
+    private String getValueSafely(OpenGraph openGraph, String property) {
+        final OpenGraph.Content content;
+        try {
+            content = openGraph.getContentOf(property);
+        } catch (ArrayIndexOutOfBoundsException | NullPointerException e) {
+            return null;
+        }
+        return content.getValue();
+    }
+}

--- a/module-api/src/main/java/inspiration/inspiration/opengraph/OpenGraphServiceImpl.java
+++ b/module-api/src/main/java/inspiration/inspiration/opengraph/OpenGraphServiceImpl.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 @Service
 public class OpenGraphServiceImpl implements OpenGraphService {
     public Optional<OpenGraphVo> getMetadata(String url) {
+        // FIXME: DI 적용 (모듈 의존성 개선 후 api 모듈에서 bean 생성해야함)
         OgParser ogParser = new OgParser(new YgtangOgMetaElementHtmlParser());
         OpenGraph openGraph = ogParser.getOpenGraphOf(url);
         if (openGraph.getAllProperties().isEmpty()) {

--- a/module-api/src/main/java/inspiration/inspiration/opengraph/OpenGraphVo.java
+++ b/module-api/src/main/java/inspiration/inspiration/opengraph/OpenGraphVo.java
@@ -1,0 +1,18 @@
+package inspiration.inspiration.opengraph;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Value;
+
+@SuppressWarnings("ClassCanBeRecord")
+@Value
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class OpenGraphVo {
+    String description;
+    String siteName;
+    String title;
+    String url;
+    String image;
+}

--- a/module-api/src/main/java/inspiration/inspiration/opengraph/YgtangOgMetaElementHtmlParser.java
+++ b/module-api/src/main/java/inspiration/inspiration/opengraph/YgtangOgMetaElementHtmlParser.java
@@ -31,29 +31,35 @@ public class YgtangOgMetaElementHtmlParser implements OgMetaElementHtmlParser {
                         return new OgMetaElement(property, content);
                     })
                     .collect(Collectors.toList());
-
-            // description, title 값 비어있는 경우 보정
-            Optional<OgMetaElement> descriptionOptional = ogMetaElements.stream()
-                    .filter(it -> "description".equals(it.getProperty()))
-                    .findFirst();
-            if (descriptionOptional.isEmpty() || !StringUtils.hasLength(descriptionOptional.get().getContent())) {
-                Elements metaDescription = document.select("meta[name=description]");
-                if (!metaDescription.isEmpty()) {
-                    ogMetaElements.add(
-                            new OgMetaElement("description", metaDescription.get(0).attr("content"))
-                    );
-                }
-            }
-            Optional<OgMetaElement> titleOptional = ogMetaElements.stream()
-                    .filter(it -> "title".equals(it.getProperty()))
-                    .findFirst();
-            if (titleOptional.isEmpty() || !StringUtils.hasLength(titleOptional.get().getContent())) {
-                ogMetaElements.add(new OgMetaElement("title", document.title()));
-            }
+            addDescriptionIfNotExists(ogMetaElements, document);
+            addTitleIfNotExists(ogMetaElements, document);
             return ogMetaElements;
         } catch (IOException | IndexOutOfBoundsException | IllegalArgumentException e) {
             log.warn("Failed to parse OpenGraph Metadata. url:{}", url, e);
             return Collections.emptyList();
+        }
+    }
+
+    private void addDescriptionIfNotExists(List<OgMetaElement> ogMetaElements, Document document) {
+        Optional<OgMetaElement> descriptionOptional = ogMetaElements.stream()
+                .filter(it -> "description".equals(it.getProperty()))
+                .findFirst();
+        if (descriptionOptional.isEmpty() || !StringUtils.hasLength(descriptionOptional.get().getContent())) {
+            Elements metaDescription = document.select("meta[name=description]");
+            if (!metaDescription.isEmpty()) {
+                ogMetaElements.add(
+                        new OgMetaElement("description", metaDescription.get(0).attr("content"))
+                );
+            }
+        }
+    }
+
+    private void addTitleIfNotExists(List<OgMetaElement> ogMetaElements, Document document) {
+        Optional<OgMetaElement> titleOptional = ogMetaElements.stream()
+                .filter(it -> "title".equals(it.getProperty()))
+                .findFirst();
+        if (titleOptional.isEmpty() || !StringUtils.hasLength(titleOptional.get().getContent())) {
+            ogMetaElements.add(new OgMetaElement("title", document.title()));
         }
     }
 }

--- a/module-api/src/main/java/inspiration/inspiration/opengraph/YgtangOgMetaElementHtmlParser.java
+++ b/module-api/src/main/java/inspiration/inspiration/opengraph/YgtangOgMetaElementHtmlParser.java
@@ -1,0 +1,57 @@
+package inspiration.inspiration.opengraph;
+
+import com.github.siyoon210.ogparser4j.htmlparser.OgMetaElement;
+import com.github.siyoon210.ogparser4j.htmlparser.OgMetaElementHtmlParser;
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.select.Elements;
+import org.springframework.util.StringUtils;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class YgtangOgMetaElementHtmlParser implements OgMetaElementHtmlParser {
+    @Override
+    public List<OgMetaElement> getOgMetaElementsFrom(String url) {
+        try {
+            final Document document = Jsoup.connect(url).get();
+            final Elements metaElements = document.select("meta");
+            List<OgMetaElement> ogMetaElements = metaElements.stream()
+                    .filter(m -> m.attr("property").startsWith("og:"))
+                    .map(m -> {
+                        final String property = m.attr("property").substring(3).trim();
+                        final String content = m.attr("content");
+                        return new OgMetaElement(property, content);
+                    })
+                    .collect(Collectors.toList());
+
+            // description, title 값 비어있는 경우 보정
+            Optional<OgMetaElement> descriptionOptional = ogMetaElements.stream()
+                    .filter(it -> "description".equals(it.getProperty()))
+                    .findFirst();
+            if (descriptionOptional.isEmpty() || !StringUtils.hasLength(descriptionOptional.get().getContent())) {
+                Elements metaDescription = document.select("meta[name=description]");
+                if (!metaDescription.isEmpty()) {
+                    ogMetaElements.add(
+                            new OgMetaElement("description", metaDescription.get(0).attr("content"))
+                    );
+                }
+            }
+            Optional<OgMetaElement> titleOptional = ogMetaElements.stream()
+                    .filter(it -> "title".equals(it.getProperty()))
+                    .findFirst();
+            if (titleOptional.isEmpty() || !StringUtils.hasLength(titleOptional.get().getContent())) {
+                ogMetaElements.add(new OgMetaElement("title", document.title()));
+            }
+            return ogMetaElements;
+        } catch (IOException | IndexOutOfBoundsException | IllegalArgumentException e) {
+            log.warn("Failed to parse OpenGraph Metadata. url:{}", url, e);
+            return Collections.emptyList();
+        }
+    }
+}

--- a/module-api/src/main/java/inspiration/inspiration/opengraph/YgtangOgMetaElementHtmlParser.java
+++ b/module-api/src/main/java/inspiration/inspiration/opengraph/YgtangOgMetaElementHtmlParser.java
@@ -20,17 +20,17 @@ public class YgtangOgMetaElementHtmlParser implements OgMetaElementHtmlParser {
     public List<OgMetaElement> getOgMetaElementsFrom(String url) {
         try {
             final Document document = Jsoup.connect(url)
-                    .timeout(1000)
-                    .get();
+                                           .timeout(1000)
+                                           .get();
             final Elements metaElements = document.select("meta");
             List<OgMetaElement> ogMetaElements = metaElements.stream()
-                    .filter(m -> m.attr("property").startsWith("og:"))
-                    .map(m -> {
-                        final String property = m.attr("property").substring(3).trim();
-                        final String content = m.attr("content");
-                        return new OgMetaElement(property, content);
-                    })
-                    .collect(Collectors.toList());
+                                                             .filter(m -> m.attr("property").startsWith("og:"))
+                                                             .map(m -> {
+                                                                 final String property = m.attr("property").substring(3).trim();
+                                                                 final String content = m.attr("content");
+                                                                 return new OgMetaElement(property, content);
+                                                             })
+                                                             .collect(Collectors.toList());
             addDescriptionIfNotExists(ogMetaElements, document);
             addTitleIfNotExists(ogMetaElements, document);
             return ogMetaElements;
@@ -42,8 +42,8 @@ public class YgtangOgMetaElementHtmlParser implements OgMetaElementHtmlParser {
 
     private void addDescriptionIfNotExists(List<OgMetaElement> ogMetaElements, Document document) {
         Optional<OgMetaElement> descriptionOptional = ogMetaElements.stream()
-                .filter(it -> "description".equals(it.getProperty()))
-                .findFirst();
+                                                                    .filter(it -> "description".equals(it.getProperty()))
+                                                                    .findFirst();
         if (descriptionOptional.isEmpty() || !StringUtils.hasLength(descriptionOptional.get().getContent())) {
             Elements metaDescription = document.select("meta[name=description]");
             if (!metaDescription.isEmpty()) {
@@ -56,8 +56,8 @@ public class YgtangOgMetaElementHtmlParser implements OgMetaElementHtmlParser {
 
     private void addTitleIfNotExists(List<OgMetaElement> ogMetaElements, Document document) {
         Optional<OgMetaElement> titleOptional = ogMetaElements.stream()
-                .filter(it -> "title".equals(it.getProperty()))
-                .findFirst();
+                                                              .filter(it -> "title".equals(it.getProperty()))
+                                                              .findFirst();
         if (titleOptional.isEmpty() || !StringUtils.hasLength(titleOptional.get().getContent())) {
             ogMetaElements.add(new OgMetaElement("title", document.title()));
         }

--- a/module-api/src/main/java/inspiration/inspiration/opengraph/YgtangOgMetaElementHtmlParser.java
+++ b/module-api/src/main/java/inspiration/inspiration/opengraph/YgtangOgMetaElementHtmlParser.java
@@ -19,7 +19,9 @@ public class YgtangOgMetaElementHtmlParser implements OgMetaElementHtmlParser {
     @Override
     public List<OgMetaElement> getOgMetaElementsFrom(String url) {
         try {
-            final Document document = Jsoup.connect(url).get();
+            final Document document = Jsoup.connect(url)
+                    .timeout(1000)
+                    .get();
             final Elements metaElements = document.select("meta");
             List<OgMetaElement> ogMetaElements = metaElements.stream()
                     .filter(m -> m.attr("property").startsWith("og:"))

--- a/module-web/src/main/java/inspiration/v1/inspiration/InspirationController.java
+++ b/module-web/src/main/java/inspiration/v1/inspiration/InspirationController.java
@@ -158,7 +158,7 @@ public class InspirationController {
             , @ApiResponse(code = 401, message = "토큰이 정상적으로 인증되지 않았습니다.")
     })
     public ResponseEntity<ResultResponse> inspirationList(@RequestParam @NotBlank String link) {
-        OpenGraphResponse openGraphResponse = inspirationService.getOG(link);
+        OpenGraphResponse openGraphResponse = inspirationService.getOpenGraphResponse(link);
         return ResponseEntity.ok().body(ResultResponse.from(openGraphResponse));
     }
 }


### PR DESCRIPTION
<!--
✅ Resolve: #이슈번호 형태로 입력해 주세요.
ex) Resolve: #123
-->
## 📌Linked Issues
- #95 

<!--
✅ 변경 사항을 자세히 알려주세요. (why -> what -> how)
-->
## ✏Change Details
- OpenGraph metadata 조회시 url 1개당 api 호출 한 번만 하도록 변경

<!--
✅ 추가로 전달할 내용이 있다면 적어주세요.
-->
## 💬Comment
- url -> OpenGraphResponse 형태로 캐시하거나, 병렬처리 적용하면 응답시간 개선 가능
- 항상 최신의 metadata 가 필요한지, 굳이 서버에서 metadata 파싱해야하는지 논의 필요

<!--
✅ 참고한 사이트가 있다면 공유해주세요.
-->
## 📑References
- https://opengraphprotocol.org/

## ✅Check List
- [x] 추가한 기능에 대한 테스트는 모두 완료하셨나요?
    - 로컬환경에서 naver, daum, google url 로 요청시 이전 코드와 동일한 결과 나오는 것 확인했습니다. 
- [x] 코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?
