### PR TITLE
feat: 태그 순위 조회 및 슬랙으로 파일 전송

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,5 @@
 gradleGitPropertiesPluginVersion=2.4.1
 embeddedRedisVersion=0.7.3
+apacheCommonsCsvVersion=1.9.0
+slackSdkVersion=1.24.0
+okhttpVersion=4.10.0

--- a/module-batch/build.gradle
+++ b/module-batch/build.gradle
@@ -3,6 +3,9 @@ dependencies {
     implementation project(':module-api')
     implementation 'org.springframework.boot:spring-boot-starter-batch'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation "org.apache.commons:commons-csv:$apacheCommonsCsvVersion"
+    implementation "com.slack.api:slack-api-client:$slackSdkVersion"
+    implementation "com.squareup.okhttp3:okhttp:$okhttpVersion"
 }
 
 bootJar {

--- a/module-batch/src/main/java/inspiration/application/tag/TagRankingConfig.java
+++ b/module-batch/src/main/java/inspiration/application/tag/TagRankingConfig.java
@@ -78,15 +78,9 @@ public class TagRankingConfig {
     @StepScope
     public Tasklet tagRankingTasklet() {
         return (contribution, chunkContext) -> {
-            // query data
             List<TagRankingVo> tagRankingVoList = getTagRankingVoList();
-
-            // convert to file
             File csvFile = toCsvFile(tagRankingVoList);
-
-            // send file to slack
             sendFileToSlack(csvFile);
-
             return RepeatStatus.FINISHED;
         };
     }

--- a/module-batch/src/main/java/inspiration/application/tag/TagRankingConfig.java
+++ b/module-batch/src/main/java/inspiration/application/tag/TagRankingConfig.java
@@ -1,0 +1,167 @@
+package inspiration.application.tag;
+
+import com.slack.api.Slack;
+import com.slack.api.methods.MethodsClient;
+import com.slack.api.methods.request.files.FilesUploadRequest;
+import com.slack.api.methods.response.files.FilesUploadResponse;
+import inspiration.domain.inspiration_tag.InspirationTag;
+import inspiration.domain.inspiration_tag.InspirationTagRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.JobScope;
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.launch.support.RunIdIncrementer;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.batch.support.transaction.ResourcelessTransactionManager;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Slf4j
+@ConditionalOnProperty(
+        name = "spring.batch.job.names",
+        havingValue = TagRankingConfig.JOB_NAME
+)
+@Configuration
+@RequiredArgsConstructor
+@SuppressWarnings("ClassCanBeRecord")
+public class TagRankingConfig {
+    static final String JOB_NAME = "tag-ranking-job";
+    private static final String STEP_NAME = "tag-ranking-step";
+
+    private static final DateTimeFormatter FORMATTER_YYYYMMDD = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    private final JobBuilderFactory jobBuilderFactory;
+    private final StepBuilderFactory stepBuilderFactory;
+    private final InspirationTagRepository inspirationTagRepository;
+
+    @Value("${ygtang.slack.token.bot}")
+    private String botToken;
+    @Value("${ygtang.slack.channel.monitoring-dev}")
+    private String monitoringDevChannel;
+
+    @Bean
+    public Job tagRankingJob() {
+        return jobBuilderFactory.get(JOB_NAME)
+                                .incrementer(new RunIdIncrementer())
+                                .start(tagRankingStep())
+                                .build();
+    }
+
+    @Bean
+    @JobScope
+    public Step tagRankingStep() {
+        return stepBuilderFactory.get(STEP_NAME)
+                                 .tasklet(tagRankingTasklet())
+                                 .transactionManager(new ResourcelessTransactionManager())
+                                 .build();
+    }
+
+    @Bean
+    @StepScope
+    public Tasklet tagRankingTasklet() {
+        return (contribution, chunkContext) -> {
+            // query data
+            List<TagRankingVo> tagRankingVoList = getTagRankingVoList();
+
+            // convert to file
+            File csvFile = toCsvFile(tagRankingVoList);
+
+            // send file to slack
+            sendFileToSlack(csvFile);
+
+            return RepeatStatus.FINISHED;
+        };
+    }
+
+    private List<TagRankingVo> getTagRankingVoList() {
+        List<InspirationTag> inspirationTags = inspirationTagRepository.findAll();
+
+        Map<String, Set<Long>> contentTagIdSetMap =
+                inspirationTags.stream()
+                               .collect(Collectors.toMap(
+                                       it -> it.getTag().getContent(),
+                                       it -> Stream.of(it.getTag().getId()).collect(Collectors.toSet()),
+                                       (a, b) -> {
+                                           Set<Long> c = new HashSet<>(a);
+                                           c.addAll(b);
+                                           return c;
+                                       }
+                               ));
+        Map<String, Set<Long>> contentInspirationIdSetMap =
+                inspirationTags.stream()
+                               .collect(Collectors.toMap(
+                                       it -> it.getTag().getContent(),
+                                       it -> Stream.of(it.getInspiration().getId()).collect(Collectors.toSet()),
+                                       (a, b) -> {
+                                           Set<Long> c = new HashSet<>(a);
+                                           c.addAll(b);
+                                           return c;
+                                       }
+                               ));
+        return contentInspirationIdSetMap.keySet()
+                                         .stream()
+                                         .map(content -> new TagRankingVo(
+                                                 content,
+                                                 contentTagIdSetMap.get(content).size(),
+                                                 contentInspirationIdSetMap.get(content).size()
+                                         ))
+                                         .sorted(Comparator.comparing(TagRankingVo::getInspirationCount)
+                                                           .thenComparing(TagRankingVo::getTagCount)
+                                                           .reversed())
+                                         .filter(it -> it.getTagCount() >= 2 || it.getInspirationCount() >= 2)
+                                         .collect(Collectors.toList());
+    }
+
+    private File toCsvFile(List<TagRankingVo> tagRankingVoList) throws IOException {
+        File file = File.createTempFile("tagRanking", "csv");
+        file.deleteOnExit();
+        FileWriter out = new FileWriter(file);
+        CSVFormat csvFormat = CSVFormat.Builder.create()
+                                               .setHeader(TagRankingVo.getCsvHeaders())
+                                               .build();
+        try (CSVPrinter printer = new CSVPrinter(out, csvFormat)) {
+            for (TagRankingVo tagRankingVo : tagRankingVoList) {
+                printer.printRecord(tagRankingVo.getCsvValues());
+            }
+        }
+        return file;
+    }
+
+    private void sendFileToSlack(File file) {
+        LocalDate today = LocalDate.now();
+        try (Slack slack = Slack.getInstance()) {
+            MethodsClient methods = slack.methods(botToken);
+            FilesUploadResponse response = methods.filesUpload(
+                    FilesUploadRequest.builder()
+                                      .channels(Collections.singletonList(monitoringDevChannel))
+                                      .title("Tag ranking at " + today)
+                                      .filename("tagRanking_" + today.format(FORMATTER_YYYYMMDD) + ".csv")
+                                      .filetype("text/csv")
+                                      .file(file)
+                                      .build()
+            );
+            log.info("response: {}", response);
+        } catch (Exception e) {
+            log.error("Failed to send file to slack", e);
+        }
+    }
+
+}

--- a/module-batch/src/main/java/inspiration/application/tag/TagRankingVo.java
+++ b/module-batch/src/main/java/inspiration/application/tag/TagRankingVo.java
@@ -1,0 +1,24 @@
+package inspiration.application.tag;
+
+import lombok.Value;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+
+@Value
+@SuppressWarnings("ClassCanBeRecord")
+public class TagRankingVo {
+    String tagName;
+    Integer inspirationCount;
+    Integer tagCount;
+
+    public static String[] getCsvHeaders() {
+        return Arrays.stream(TagRankingVo.class.getDeclaredFields())
+                     .map(Field::getName)
+                     .toArray(String[]::new);
+    }
+
+    public Object[] getCsvValues() {
+        return new Object[]{tagName, inspirationCount, tagCount};
+    }
+}

--- a/module-batch/src/main/resources/batch.yml
+++ b/module-batch/src/main/resources/batch.yml
@@ -10,3 +10,8 @@ ygtang:
       username: ${DB_USER}
       password: ${DB_PASSWORD}
       driver-class-name: com.mysql.cj.jdbc.Driver
+  slack:
+    token:
+      bot: ${YGTANG_SLACK_TOKEN_BOT}
+    channel:
+      monitoring-dev: "#monitoring-yg-dev"

--- a/module-domain/src/main/java/inspiration/domain/inspiration/Inspiration.java
+++ b/module-domain/src/main/java/inspiration/domain/inspiration/Inspiration.java
@@ -21,7 +21,7 @@ public class Inspiration extends BaseTimeEntity {
     @Column(name = "inspiration_id")
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 

--- a/module-domain/src/main/java/inspiration/domain/tag/Tag.java
+++ b/module-domain/src/main/java/inspiration/domain/tag/Tag.java
@@ -23,7 +23,7 @@ public class Tag extends BaseTimeEntity {
     @OneToMany(mappedBy = "tag", fetch = FetchType.LAZY)
     private List<InspirationTag> inspirationTags;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
@@ -33,11 +33,5 @@ public class Tag extends BaseTimeEntity {
     public void writeBy(Member member) {
         this.member = member;
     }
-
-
-//    public void taggedBy(Inspiration inspiration) {
-//        this.inspirations.add(inspiration);
-//        inspiration.tagInspiration(this);
-//    }
 
 }


### PR DESCRIPTION
<!--
✅ Resolve: #이슈번호 형태로 입력해 주세요.
ex) Resolve: #123
-->
## 📌Linked Issues
- resolve #131 

<!--
✅ 변경 사항을 자세히 알려주세요. (why -> what -> how)
-->
## ✏Change Details
- 태그 순위조회 배치 추가
- 조회 결과 csv 파일로 변환해서 슬랙 채널로 발송

<!--
✅ 추가로 전달할 내용이 있다면 적어주세요.
-->
## 💬Comment
- JPA 에서 from절 에서 subquery 지원이 안되어서, 일단 여러번 쿼리하는 방향으로 개발했습니다. 
- 좀 사용해보고 사용 패턴 따라서 노티 방법, 파일 내용 등을 개선할 예정입니다. 

## ✅Check List
- [x] 추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [x] 코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?
